### PR TITLE
Name install directory 'podcast'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,8 @@
 	"require": {
 		"silverstripe/framework": ">=3.1.x-dev,<4.0",
 		"silverstripe/cms": ">=3.1.x-dev,<4.0"
+	},
+	"extra": {
+		"installer-name": "podcast"
 	}
 }


### PR DESCRIPTION
Currently installs in folder called 'silverstripe-podcast' breaking references. This change should name the folder 'podcast' when installed through composer
