### PR TITLE
Improved templating.

### DIFF
--- a/code/pagetypes/PodcastPage.php
+++ b/code/pagetypes/PodcastPage.php
@@ -179,16 +179,11 @@ class PodcastPage extends Page {
 }
 
 class PodcastPage_Controller extends Page_Controller {
-	public static $allowed_actions = array('rss', 'episode');
+	private static $allowed_actions = array(
+		'rss', 'episode'
+	);
 
 	public function init() {
-		// Adds the requirements for the Podcast and Episode Page in the correct order
-		Requirements::javascript('framework/thirdparty/jquery/jquery.js');
-		Requirements::javascript('podcast/thirdparty/mediaelement/mediaelement-and-player.min.js');
-		Requirements::javascript('podcast/javascript/podcast-page.js');
-		Requirements::css('podcast/thirdparty/mediaelement/mediaelementplayer.min.css');
-		Requirements::css('podcast/css/podcast-page.css');
-		
 		// Provides a link to the Podcast RSS in the HTML head
 		RSSFeed::linkToFeed($this->Link('rss'));
 		
@@ -237,6 +232,6 @@ class PodcastPage_Controller extends Page_Controller {
 	public function episode() {
 		$episode = PodcastEpisode::get()->byID($this->Request->param("ID"));
 		if(!$episode) return $this->httpError(404);
-		return $this->customise(array("PodcastEpisode" => $episode))->renderWith(array("PodcastEpisode", "Page"));
+		return array("PodcastEpisode" => $episode);
 	}
 }

--- a/templates/Includes/PodcastRequirements.ss
+++ b/templates/Includes/PodcastRequirements.ss
@@ -1,0 +1,6 @@
+<%-- Adds the requirements for the Podcast and Episode Page in the correct order --%>
+<% require javascript('framework/thirdparty/jquery/jquery.js') %>
+<% require javascript('podcast/thirdparty/mediaelement/mediaelement-and-player.min.js') %>
+<% require javascript('podcast/javascript/podcast-page.js') %>
+<% require css('podcast/thirdparty/mediaelement/mediaelementplayer.min.css') %>
+<% require css('podcast/css/podcast-page.css') %>

--- a/templates/Layout/PodcastPage.ss
+++ b/templates/Layout/PodcastPage.ss
@@ -1,4 +1,5 @@
-<div class="podcast">
+<% include PodcastRequirements %>
+div class="podcast">
 	<header class="podcast-details">
 		<% if $PodcastTitle %><h1>$PodcastTitle</h1><% end_if %>
 		<% if $PodcastImage %><% with PodcastImage.setWidth(200) %><img src="$URL" alt="$Title" class="left"><% end_with %><% end_if %>

--- a/templates/Layout/PodcastPage_episode.ss
+++ b/templates/Layout/PodcastPage_episode.ss
@@ -1,3 +1,4 @@
+<% include PodcastRequirements %>
 <div class="PodcastEpisode">
 <% with PodcastEpisode %><% if not $BlockEpisode %>
 	<% if $EpisodeTitle %><h1>$EpisodeTitle</h1><% end_if %>


### PR DESCRIPTION
The files that are required via `PodcastPage_Controller::init` are only relevant for the default templates. It is therefore reasonable to move the requirements to the templates instead, so that the page is easier to customize.

Also make use of the default SilverStripe template syntax/inheritance and use `PodcastPage_episode` instead of a separate template name.

This PR also fixes visibility of `PodcastPage::$allowed_actions` (should be private).